### PR TITLE
generateコマンド_ファイル指定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,20 @@ module WHISKER
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    #rails generateコマンドで作成されるファイルの指定
+    config.generators do |g|
+      g.skip_routes true
+      g.assets false
+      g.helper false
+      g.test_framework false :rspec,
+                              view_specs: false,
+                              helper_specs: false,
+                              routing_specs: false,
+                              controller_specs: false,
+                              request_specs: true,
+                              model_spec: true,
+                              fixtures: true
+    end
   end
 end


### PR DESCRIPTION
generateコマンドのファイル指定を実装。
config/application.rb内に記述。