### PR TITLE
Carrierwave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,7 @@ gem 'jquery-rails'
 gem 'sorcery'
 gem 'pry-byebug'
 gem 'rails-i18n'
+#画像を投稿するためのgem
+gem 'carrierwave'
+#画像のサイズ調整のためのgem
+gem 'mini_magick'

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'bootstrap'
+gem 'bootstrap', '~> 4.3.1'
 gem 'font-awesome-sass', '~> 5.11.2'
 gem 'jquery-rails'
 gem 'sorcery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,9 +75,9 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    bootstrap (5.2.3)
+    bootstrap (4.3.1)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.11.6, < 3)
+      popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     bullet (7.0.7)
@@ -184,7 +184,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
-    popper_js (2.11.6)
+    popper_js (1.16.1)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -348,7 +348,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.4)
-  bootstrap
+  bootstrap (~> 4.3.1)
   bullet
   byebug
   capybara

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (2.2.3)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
@@ -120,6 +128,9 @@ GEM
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -143,6 +154,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
@@ -260,6 +272,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -293,6 +307,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.0-arm64-darwin)
+    ssrf_filter (1.1.1)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.2)
@@ -337,12 +352,14 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  carrierwave
   factory_bot_rails
   faker
   font-awesome-sass (~> 5.11.2)
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)
+  mini_magick
   pry-byebug
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -31,6 +31,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :image, :price, :whiskey_brand, countries_attributes: [:id, :name, :_destroy], whiskey_types_attributes: [:id, :name, :_destroy])
+    params.require(:post).permit(:title, :body, :post_image, :post_image_cache, :price, :whiskey_brand, countries_attributes: [:id, :name, :_destroy], whiskey_types_attributes: [:id, :name, :_destroy])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,6 @@
 class Post < ApplicationRecord
+  #Board モデルに、アップローダーの仕様を宣言しておく
+  mount_uploader :post_image, PostImageUploader
   belongs_to :user
   
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -1,4 +1,5 @@
 class PostImageUploader < CarrierWave::Uploader::Base
+  
   storage :file
   
   def store_dir

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -1,0 +1,16 @@
+class PostImageUploader < CarrierWave::Uploader::Base
+  storage :file
+  
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def default_url
+    'post_placeholder.png'
+  end
+
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
+
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    
   </head>
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -28,5 +28,10 @@
     <%= f.label :price %>
     <%= f.text_field :price, class: 'form-control' %>
   </div>
+  <div class="form-group">
+    <%= f.label :post_image %>
+    <%= f.file_field :post_image, class: 'form-control mb-3', accept: 'image/*' %>
+    <%= f.hidden_field :post_image_cache %>
+  </div>
   <%= f.submit class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,9 +2,7 @@
   <div id="post-id-<%= post.id %>">
     <div class="row">
       <div class="col-md-7">
-        <a href="#">
-          <img class="img-fluid rounded mb-3 mb-md-0" src="https://via.placeholder.com/700x300" alt="">
-        </a>
+        <%= image_tag post.post_image_url, class: 'card-img-top', size: '700x300' %>
       </div>
       <div class="col-md-5">
         <div class="card-body">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,6 +14,7 @@ ja:
         body: '本文'
         whiskey_brand: '銘柄'
         price: '価格'
+        post_image: 'サムネイル'
       whiskey_type:
         name: '原材料'
       country:

--- a/db/migrate/20230216084135_rename_image_to_posts.rb
+++ b/db/migrate/20230216084135_rename_image_to_posts.rb
@@ -1,0 +1,5 @@
+class RenameImageToPosts < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :posts, :image, :post_image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_13_064755) do
+ActiveRecord::Schema.define(version: 2023_02_16_084135) do
 
   create_table "countries", force: :cascade do |t|
     t.string "name", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2023_02_13_064755) do
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.string "body", null: false
-    t.string "image"
+    t.string "post_image"
     t.integer "price", null: false
     t.string "whiskey_brand", null: false
     t.integer "user_id", null: false


### PR DESCRIPTION
Carrierwaveの実装

・Postモデルにpost_imageカラムの追加
・uploaderファイルにデフォルト設定
・新規投稿画面のviewファイルの変更
・一覧画面へ投稿した画像が貼り付くように変更